### PR TITLE
Fix Logo redirecting to #

### DIFF
--- a/resources/views/GoldFish/layouts/base.blade.php
+++ b/resources/views/GoldFish/layouts/base.blade.php
@@ -42,7 +42,7 @@
       @endif
       <div class="container relative">
         <div class="logo">
-          <a href="#" class="left"><img src="{{CMSHelper::settings('site_logo')}}"/></a>
+          <a href="/index" class="left"><img src="{{CMSHelper::settings('site_logo')}}"/></a>
           <div class="online no-mobile"><span id="onlinecount">{{CMSHelper::online()}}</span> Online Now</div>
         </div>
         <div class="right @guest regbutton @endguest">


### PR DESCRIPTION
When clicking logo it now redirects to /index instead of # to return either to the index page for guests or the me page for logged in users.